### PR TITLE
Fix issue where accessing array with curly brace is no longer supported

### DIFF
--- a/lib/Datamatrix.php
+++ b/lib/Datamatrix.php
@@ -617,7 +617,7 @@ class Datamatrix
 					if ($numch[self::ENC_C40] == $numch[self::ENC_X12]) {
 						$k = ($pos + $charscount + 1);
 						while ($k < $data_length) {
-							$tmpchr = ord($data{$k});
+							$tmpchr = ord($data[$k]);
 							if ($this->isCharMode($tmpchr, self::ENC_X12)) {
 								return self::ENC_X12;
 							} elseif (!($this->isCharMode($tmpchr, self::ENC_X12) OR $this->isCharMode($tmpchr, self::ENC_C40))) {


### PR DESCRIPTION
I ran into the following error on PHP 8
```
Array and string offset access syntax with curly braces is no longer supported {"trace":[],"file":"/opt/app/vendor/jucksearm/php-barcode/lib/Datamatrix.php","line":620}
```
