### PR TITLE
Added option to suppress output of generated QR code.

### DIFF
--- a/QRcode.php
+++ b/QRcode.php
@@ -16,7 +16,8 @@ class QRcode
 		$level = null,
 		$size = null,
 		$margin = null,
-		$color = null
+		$color = null,
+		$skipOutput = false
 	) {
 		$qrcodeFactory = self::factory()
 		  ->setCode($code)
@@ -25,6 +26,7 @@ class QRcode
 		  ->setSize($size)
 		  ->setMargin($margin)
 		  ->setColor($color)
+		  ->setSkipOutput($skipOutput)
 		  ->renderHTML();
 	}
 
@@ -35,7 +37,8 @@ class QRcode
 		$level = null,
 		$size = null,
 		$margin = null,
-		$color = null
+		$color = null,
+		$skipOutput = false
 	) {
 		$qrcodeFactory = self::factory()
 		  ->setCode($code)
@@ -45,6 +48,7 @@ class QRcode
 		  ->setSize($size)
 		  ->setMargin($margin)
 		  ->setColor($color)
+		  ->setSkipOutput($skipOutput)
 		  ->renderPNG();
 	}
 
@@ -55,7 +59,8 @@ class QRcode
 		$level = null,
 		$size = null,
 		$margin = null,
-		$color = null
+		$color = null,
+		$skipOutput = false
 	) {
 		$qrcodeFactory = self::factory()
 		  ->setCode($code)
@@ -65,6 +70,7 @@ class QRcode
 		  ->setSize($size)
 		  ->setMargin($margin)
 		  ->setColor($color)
+		  ->setSkipOutput($skipOutput)
 		  ->renderSVG();
 	}
 }

--- a/lib/QRcodeFactory.php
+++ b/lib/QRcodeFactory.php
@@ -21,6 +21,7 @@ class QRcodeFactory
 			'size'   => 100,
 			'margin' => 1,
 			'color'  => '000',
+			'skipOutput'  => false,
 		];
 	}
 
@@ -157,6 +158,17 @@ class QRcodeFactory
 	{
 		return $this->getAttribute('color');
 	}	
+
+	public function setSkipOutput($value=false)
+	{
+		$this->setAttribute('skipOutput', $value);
+		return $this;
+	}
+
+	public function getSkipOutput()
+	{
+		return $this->getAttribute('skipOutput');
+	}
 
 	public function getBarcode()
 	{
@@ -405,37 +417,49 @@ class QRcodeFactory
 
 	public function renderHTML()
 	{
-		$qrcodeData = $this->getQRcodeHtmlData();
+		if(!empty($this->getSkipOutput())){
+			$this->getQRcodeHtmlData();
+		} else {
+			$qrcodeData = $this->getQRcodeHtmlData();
 
-		header('Content-Type: text/html');
-		header('Content-Length: '.strlen($qrcodeData));
-		header('Cache-Control: no-cache');
-		header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+			header('Content-Type: text/html');
+			header('Content-Length: '.strlen($qrcodeData));
+			header('Cache-Control: no-cache');
+			header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
 
-		echo $qrcodeData;
+			echo $qrcodeData;
+		}
 	}
 
 	public function renderPNG()
 	{
-		$qrcodeData = $this->getQRcodePngData();
+		if(!empty($this->getSkipOutput())){
+			$this->getQRcodePngData();
+		} else {
+			$qrcodeData = $this->getQRcodePngData();
 
-		header('Content-Type: image/png');
-		header('Content-Length: '.strlen($qrcodeData));
-		header('Cache-Control: no-cache');
-		header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');			
-			
-		echo $qrcodeData;
+			header('Content-Type: image/png');
+			header('Content-Length: '.strlen($qrcodeData));
+			header('Cache-Control: no-cache');
+			header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+			echo $qrcodeData;
+		}
 	}
 
 	public function renderSVG()
 	{
-		$qrcodeData = $this->getQRcodeSvgData();
-		
-		header('Content-Type: image/svg+xml');
-		header('Content-Length: '.strlen($qrcodeData));
-		header('Cache-Control: no-cache');
-		header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');	
+		if(!empty($this->getSkipOutput())){
+			$this->getQRcodeSvgData();
+		} else {
+			$qrcodeData = $this->getQRcodeSvgData();
 
-		echo $qrcodeData;
+			header('Content-Type: image/svg+xml');
+			header('Content-Length: '.strlen($qrcodeData));
+			header('Cache-Control: no-cache');
+			header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+			echo $qrcodeData;
+		}
 	}
 }


### PR DESCRIPTION
Usage Before:
```
 $qr_factory = QRcode::factory()->setCode($generatedString)->setFile($qr_file_path);
 $qr_factory->getQRcodePngData();
```
Usage After this PR:
```
1: QRcode::png($generatedString, null, $qr_file_path, null, null, null, null, true);
2: QRcode::factory()->setCode($generatedString)->setFile($qr_file_path)->setSkipOutput(true)->renderPNG();
```
This change allows the QR code generation function to save the QR code image to a file without sending any output to the browser or client.

Reason:
An absolute path was needed for rendering the barcode in a PDF using the PHP mPDF library. However, the Barcode library was also outputting content to the browser with an echo statement. This PR suppresses the echo statement, allowing only the file to be saved."